### PR TITLE
Updated graham-campbell/markdown to be laravel 5.5 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Events module for laralum",
     "require": {
         "laralum/laralum": "^1.1.2",
-        "graham-campbell/markdown": "7.*",
+        "graham-campbell/markdown": "^8.0",
         "league/html-to-markdown": "4.*"
     },
     "license": "MIT",


### PR DESCRIPTION
Exactly as the title suggests the composer.json was updated to pull the newer library.